### PR TITLE
Add destination path to Add Torrent node

### DIFF
--- a/transmission.html
+++ b/transmission.html
@@ -85,6 +85,10 @@
          <label for="node-input-url"><i class="fa fa-tag"></i> Url</label>
          <input type="text" id="node-input-url" placeholder="url">
     </div>
+    <div class="form-row node-input-path">
+        <label for="node-input-path"><i class="fa fa-tag"></i> Destination folder</label>
+        <input type="text" id="node-input-path" placeholder="/home/user">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="Transmission Add Torrent">
@@ -100,7 +104,8 @@
         defaults: {
             config: {type:"transmission-config",required:true},
             url: {value: "",required:false},
-            name: {value:""}
+            name: {value:""},
+            path: {value:"",required:false}
         },
         inputs:1,
         outputs:1,

--- a/transmission.js
+++ b/transmission.js
@@ -105,12 +105,14 @@ module.exports = function(RED) {
     node.on("input", function(msg) {
       node.log("Entering Add Torrent section");
       node.status({fill:"blue",shape:"dot",text:"Calling Transmission"});
-      var url;
+      var url, path;
       var msg2 = {};
       url = msg.url || n.url;
+      path = msg.path || n.path;
       node.log(url);
+      node.log(path);
 
-      TransmissionAPI.addUrl(url,function(err, result) {
+      TransmissionAPI.addUrl(url,{"download-dir":path},function(err, result) {
         node.status({fill:"green", shape:"dot", text:"processing"});
 
         msg.topic = "/transmission.v1/torrentAdd";


### PR DESCRIPTION
This add a new input box to the Add Torrent node in order to let us choose the destination folder, this opens the possibility to have several flows saving using different locations to save the files. 